### PR TITLE
Fix webview popup when using local baseUrl

### DIFF
--- a/Rtt_LinuxWebPopup.cpp
+++ b/Rtt_LinuxWebPopup.cpp
@@ -120,7 +120,7 @@ void LinuxWebPopup::Show(const MPlatform& platform, const char *url)
 		platform->PathForFile(url, fBaseDirectory, MPlatform::kDefaultPathFlags, filePath);
 		if (!filePath.IsEmpty())
 		{
-			updatedUrl = filePath.GetString();
+			updatedUrl = std::string("file://") + filePath.GetString();
 		}
 	}
 	else if (fBaseUrl.size() > 0)


### PR DESCRIPTION
URLs to local files need to have "file://" prepended to them before being passed to wxWebView in order to work.